### PR TITLE
fix: install deps + chromium before live route sweep

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -305,6 +305,12 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install dependencies for route sweep
+        run: npm ci --legacy-peer-deps --no-audit --no-fund 2>&1 || npm install --no-audit --no-fund --legacy-peer-deps 2>&1
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
       - name: Run strict live readiness gate
         env:
           FRONTEND_URL: https://pvabazaar.org

--- a/.github/workflows/live-readiness.yml
+++ b/.github/workflows/live-readiness.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install dependencies for route sweep
+        run: npm ci --legacy-peer-deps --no-audit --no-fund 2>&1 || npm install --no-audit --no-fund --legacy-peer-deps 2>&1
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
       - name: Run live readiness (non-strict on push)
         if: github.event_name != 'workflow_dispatch' || inputs.strict != true
         env:


### PR DESCRIPTION
Readiness gates ran node scripts/verify-frontend-routes-live.mjs without installing playwright, failing post-deploy verification. Add npm ci + chromium install to deploy-frontend.yml and live-readiness.yml.