### PR TITLE
fix: bootstrap DB connection in serverless entry + careerQuiz fallback

### DIFF
--- a/backend/api/index-serverless.js
+++ b/backend/api/index-serverless.js
@@ -94,6 +94,14 @@ async function ensureDatabaseState() {
   return getMongoState();
 }
 
+// Kick off the DB connection as early as possible so route handlers
+// (careerQuiz, commodities, contacts, templates) don't buffer on a closed
+// default mongoose connection. Safe to fire-and-forget: connectMongo caches
+// its promise, and the middleware below awaits it for DB-backed routes.
+ensureDatabaseState().catch((err) => {
+  console.warn('[serverless] background DB bootstrap failed:', err?.message || err);
+});
+
 app.use(async (req, res, next) => {
   res.setHeader('Vary', 'Origin');
   const origin = req.headers.origin || '';
@@ -122,6 +130,30 @@ app.use(async (req, res, next) => {
 app.use((req, _res, next) => {
   req.requestId = crypto.randomUUID();
   next();
+});
+
+// Ensure the default mongoose connection is open before DB-backed route handlers
+// run. Health/diagnostics endpoints are skipped so they stay fast and independent.
+app.use(async (req, res, next) => {
+  const skipPaths = [
+    '/api/health',
+    '/api/health-check',
+    '/api/mongo-diag',
+    '/api/ping',
+    '/api/version',
+    '/api/openapi.json',
+    '/api/docs',
+    '/api/decentralized',
+  ];
+  if (skipPaths.some((p) => req.path === p || req.path.startsWith(p))) {
+    return next();
+  }
+  try {
+    await ensureDatabaseState();
+  } catch (err) {
+    console.warn('[serverless] DB ensure failed:', err?.message || err);
+  }
+  return next();
 });
 
 app.get('/api/health', async (_req, res) => {

--- a/backend/routes/careerQuiz.js
+++ b/backend/routes/careerQuiz.js
@@ -369,9 +369,14 @@ function validateQuestions(questions) {
 }
 
 async function getActiveQuizDefinition() {
-  const active = await CareerQuizDefinition.findOne({ isActive: true })
-    .sort({ updatedAt: -1, _id: -1 })
-    .lean();
+  let active = null;
+  try {
+    active = await CareerQuizDefinition.findOne({ isActive: true })
+      .sort({ updatedAt: -1, _id: -1 })
+      .lean();
+  } catch (err) {
+    console.warn('[careerQuiz] definition query failed, using defaults:', err?.message || err);
+  }
 
   if (active) {
     return {


### PR DESCRIPTION
Fixes live career-quiz timeout.

**Root cause:** \ackend/api/index-serverless.js\ defined \ensureDatabaseState()\ but never called it — the default mongoose connection never opened on Vercel (\/api/decentralized/status\ showed \mode: disconnected\). Archive worked only via static fallback; \getActiveQuizDefinition()\ queried Mongo directly and buffered until timeout.

**Changes:**
- Kick off \ensureDatabaseState()\ at boot (fire-and-forget, connectMongo caches its promise).
- Middleware awaits DB connection before DB-backed routes (skips health/diag paths).
- \getActiveQuizDefinition()\ now catches query errors and falls back to \DEFAULT_QUESTIONS\.

**Verified:** serverless entry loads; mock-mode \/api/career-quiz/definition\ returns 200 with defaults; 31 backend tests pass.