### PR TITLE
fix: pass Vercel secrets to sanctuary validate step

### DIFF
--- a/.github/workflows/deploy-sanctuary.yml
+++ b/.github/workflows/deploy-sanctuary.yml
@@ -29,6 +29,9 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Validate Vercel secrets
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID || vars.VERCEL_ORG_ID }}
+          VERCEL_SANCTUARY_PROJECT_ID: ${{ secrets.VERCEL_SANCTUARY_PROJECT_ID || vars.VERCEL_SANCTUARY_PROJECT_ID }}
         run: |
           missing=0
           for name in VERCEL_ORG_ID VERCEL_SANCTUARY_PROJECT_ID; do


### PR DESCRIPTION
The Validate Vercel secrets step checks shell env vars (via \) but never received the secrets — they were only attached to later steps. Added the env: mapping so the gate actually sees VERCEL_ORG_ID / VERCEL_SANCTUARY_PROJECT_ID.