### PR TITLE
fix: run sanctuary deploy from repo root

### DIFF
--- a/.github/workflows/deploy-sanctuary.yml
+++ b/.github/workflows/deploy-sanctuary.yml
@@ -13,10 +13,6 @@ jobs:
     name: Deploy Next.js sanctuary to Vercel (Production)
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: apps/pva-bazaar-web
-
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The deploy steps previously ran with working-directory apps/pva-bazaar-web, while the Vercel project also has rootDirectory apps/pva-bazaar-web — Vercel CLI applied the path twice. Run from repo root so the project's rootDirectory applies once.