### PR TITLE
feat: richer referral dashboard — clicks, conversion, payout history

### DIFF
--- a/Frontend/src/components/ReferralTab.jsx
+++ b/Frontend/src/components/ReferralTab.jsx
@@ -113,6 +113,7 @@ export default function ReferralTab() {
               <th>Email / Name</th>
               <th>Rate</th>
               <th>Sales</th>
+              <th>Clicks</th>
               <th>Pending</th>
               <th>Lifetime</th>
               <th>Status</th>
@@ -145,6 +146,7 @@ export default function ReferralTab() {
                   )}
                 </td>
                 <td>{r.sales || 0}</td>
+                <td>{r.clicks || 0}</td>
                 <td className="referral-amount">{formatCents(r.pendingCents)}</td>
                 <td className="referral-amount">{formatCents(r.totalCommissionsCents)}</td>
                 <td>

--- a/Frontend/src/pages/ReferralPage.css
+++ b/Frontend/src/pages/ReferralPage.css
@@ -209,6 +209,62 @@
   font-size: 1.1rem;
 }
 
+.referral-page__activity {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.referral-page__activityRow {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  border: 1px solid var(--site-border);
+  border-radius: 12px;
+  background: var(--site-panel);
+  padding: 0.75rem 0.9rem;
+}
+
+.referral-page__activityKind {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--site-accent);
+  color: var(--site-accent-strong);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.25rem 0.6rem;
+}
+
+.referral-page__activityDetail {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  gap: 0.15rem;
+}
+
+.referral-page__activityDetail strong {
+  color: var(--site-text);
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.referral-page__activityDetail small {
+  color: var(--site-text-muted);
+  font-size: 0.78rem;
+}
+
+.referral-page__activityAmount {
+  flex: 0 0 auto;
+  color: var(--site-accent-strong);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
 .referral-page__faqList {
   display: grid;
   gap: 0.75rem;

--- a/Frontend/src/pages/ReferralPage.jsx
+++ b/Frontend/src/pages/ReferralPage.jsx
@@ -46,6 +46,14 @@ function getInboundReferral() {
   } catch (_e) { return ''; }
 }
 
+function formatConversion(clicks, sales) {
+  const safeClicks = Number(clicks) || 0;
+  const safeSales = Number(sales) || 0;
+  if (safeClicks <= 0) return '—';
+  const rate = (safeSales / safeClicks) * 100;
+  return rate < 0.05 && safeSales === 0 ? '0%' : `${rate.toFixed(1)}%`;
+}
+
 // ── commission tiers ─────────────────────────────────────────────────────────
 
 const TIERS = [
@@ -371,6 +379,10 @@ export default function ReferralPage() {
                   <strong>{live?.sales ?? data.sales ?? 0}</strong>
                 </div>
                 <div className="referral-page__stat">
+                  <span>Conversion</span>
+                  <strong>{formatConversion(live?.clicks ?? data.clicks ?? 0, live?.sales ?? data.sales ?? 0)}</strong>
+                </div>
+                <div className="referral-page__stat">
                   <span>Earnings</span>
                   <strong>${((live?.totalCommissionsCents ?? data.totalCommissionsCents ?? 0) / 100).toFixed(2)}</strong>
                 </div>
@@ -383,6 +395,8 @@ export default function ReferralPage() {
                 Reset and create new code
               </button>
             </section>
+
+            <ActivityList payouts={live?.payouts ?? []} recent={live?.recent ?? []} />
 
             <section className="referral-page__send section-card">
               <p className="pill">Send your code by email</p>
@@ -452,5 +466,60 @@ export default function ReferralPage() {
         </div>
       </section>
     </>
+  );
+}
+
+function ActivityList({ payouts = [], recent = [] }) {
+  if (payouts.length === 0 && recent.length === 0) {
+    return (
+      <section className="referral-page__send section-card">
+        <p className="pill">Activity</p>
+        <h2>Your recent activity</h2>
+        <p>
+          No activity yet. Share your link — every click and purchase through it will show up here,
+          along with any payouts.
+        </p>
+      </section>
+    );
+  }
+
+  const rows = [
+    ...payouts.map((p) => ({
+      key: `payout-${p.batchId || p.createdAt}`,
+      kind: 'Payout',
+      detail: p.status === 'completed' ? 'Paid out' : `Status: ${p.status}`,
+      amountCents: p.netPayoutCents ?? 0,
+      sub: `${p.orderCount ?? 0} order(s) · batch ${String(p.batchId || '').slice(0, 8)}`,
+      date: p.createdAt,
+    })),
+    ...recent.map((entry) => ({
+      key: `sale-${entry.orderId || entry._id || entry.createdAt}`,
+      kind: 'Sale',
+      detail: entry.itemName ? String(entry.itemName).slice(0, 60) : 'Purchase via your link',
+      amountCents: entry.commissionCents ?? 0,
+      sub: entry.orderId ? `Order ${String(entry.orderId).slice(0, 12)}` : 'Commission recorded',
+      date: entry.createdAt || entry.settledAt,
+    })),
+  ];
+
+  return (
+    <section className="referral-page__send section-card">
+      <p className="pill">Activity</p>
+      <h2>Your recent activity</h2>
+      <ul className="referral-page__activity">
+        {rows.slice(0, 12).map((row) => (
+          <li key={row.key} className="referral-page__activityRow">
+            <span className="referral-page__activityKind">{row.kind}</span>
+            <span className="referral-page__activityDetail">
+              <strong>{row.detail}</strong>
+              <small>{row.sub} · {new Date(row.date).toLocaleDateString()}</small>
+            </span>
+            <span className="referral-page__activityAmount">
+              {row.amountCents >= 0 ? '+' : ''}${(Math.abs(row.amountCents) / 100).toFixed(2)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/apps/pva-bazaar-web/src/app/referrals/page.tsx
+++ b/apps/pva-bazaar-web/src/app/referrals/page.tsx
@@ -23,16 +23,28 @@ interface ReferralData {
   }[];
 };
 
+interface PayoutEntry {
+  status: string;
+  totalCommissionsCents: number;
+  netPayoutCents: number;
+  orderCount: number;
+  batchId: string;
+  createdAt: string;
+}
+
 interface EarningsResult {
   code: string;
   name: string;
   commissionRate: number;
   sales: number;
+  clicks: number;
+  lastClickedAt: string;
   totalCommissionsCents: number;
   pendingCents: number;
   joinedAt: string;
   status: string;
   recent: ReferralData["recent"];
+  payouts: PayoutEntry[];
 }
 
 export default function ReferralsPage() {
@@ -133,6 +145,10 @@ export default function ReferralsPage() {
   }
 
   const cents = (value: number) => (Number(value || 0) / 100).toFixed(2);
+  const conversion =
+    stats && Number(stats.clicks) > 0
+      ? `${((Number(stats.sales) / Number(stats.clicks)) * 100).toFixed(1)}%`
+      : "—";
 
   return (
     <section className="flex w-full flex-col gap-8">
@@ -244,7 +260,8 @@ export default function ReferralsPage() {
           <p className="text-xs uppercase tracking-[0.3em] text-zinc-500">Step 2 · Your records</p>
           <h2 className="mt-1 text-lg font-semibold text-zinc-100">Check your earnings</h2>
           <p className="mt-1 text-sm text-zinc-400">
-            Enter the email attached to your code to see sales, pending kickbacks and lifetime totals.
+            Enter the email attached to your code to see link clicks, sales, conversion, pending
+            kickbacks, lifetime totals and payout history.
           </p>
           <form onSubmit={handleEarnings} className="mt-4 space-y-3">
             <label className="block text-sm text-zinc-300">
@@ -271,7 +288,7 @@ export default function ReferralsPage() {
 
           {stats ? (
             <div className="mt-5 space-y-3">
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 <div className="rounded-lg border border-zinc-800 bg-black/40 p-3">
                   <p className="text-[10px] uppercase tracking-widest text-zinc-500">Code</p>
                   <p className="truncate text-sm font-semibold text-zinc-100">{stats.code}</p>
@@ -279,6 +296,14 @@ export default function ReferralsPage() {
                 <div className="rounded-lg border border-zinc-800 bg-black/40 p-3">
                   <p className="text-[10px] uppercase tracking-widest text-zinc-500">Sales</p>
                   <p className="text-sm font-semibold text-zinc-100">{stats.sales}</p>
+                </div>
+                <div className="rounded-lg border border-zinc-800 bg-black/40 p-3">
+                  <p className="text-[10px] uppercase tracking-widest text-zinc-500">Clicks</p>
+                  <p className="text-sm font-semibold text-zinc-100">{stats.clicks ?? 0}</p>
+                </div>
+                <div className="rounded-lg border border-zinc-800 bg-black/40 p-3">
+                  <p className="text-[10px] uppercase tracking-widest text-zinc-500">Conversion</p>
+                  <p className="text-sm font-semibold text-zinc-100">{conversion}</p>
                 </div>
                 <div className="rounded-lg border border-amber-300/40 bg-amber-300/5 p-3">
                   <p className="text-[10px] uppercase tracking-widest text-amber-300">Pending</p>
@@ -298,6 +323,21 @@ export default function ReferralsPage() {
                     </li>
                   ))}
                 </ul>
+              ) : null}
+              {stats.payouts && stats.payouts.length > 0 ? (
+                <div>
+                  <p className="text-[10px] uppercase tracking-widest text-zinc-500">Payout history</p>
+                  <ul className="mt-1 space-y-1 text-xs text-zinc-400">
+                    {stats.payouts.map((p) => (
+                      <li key={`payout-${p.batchId}-${p.createdAt}`} className="rounded-lg border border-zinc-800 bg-black/30 px-3 py-2">
+                        {p.status === "completed" ? "Paid out" : `Status: ${p.status}`} ·{" "}
+                        <strong className="text-amber-200">${cents(p.netPayoutCents)}</strong> ·{" "}
+                        {p.orderCount ?? 0} order(s) ·{" "}
+                        {new Date(p.createdAt).toLocaleDateString()}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/backend/routes/__tests__/referrals.test.js
+++ b/backend/routes/__tests__/referrals.test.js
@@ -204,5 +204,32 @@ describe('Referral Module', () => {
       expect(res.body.data.recent).toHaveLength(1);
       expect(res.body.data.recent[0].itemName).toBe('Ceramic vase');
     });
+
+    it('includes clicks and payout history in the summary', async () => {
+      const reg = await referralService.registerReferral({ email: 'eli@example.com', name: 'Eli' });
+      await request(app).post(`/api/referrals/${reg.record.code}/click`).expect(200);
+      await request(app).post(`/api/referrals/${reg.record.code}/click`).expect(200);
+
+      await Payout.create({
+        batchId: `test_batch_${Date.now()}`,
+        status: 'ready',
+        payoutPeriod: { startDate: new Date(Date.now() - 86400000), endDate: new Date() },
+        creatorHandle: reg.record.code,
+        totalCommissionsCents: 500,
+        netPayoutCents: 475,
+        orderCount: 1,
+      });
+
+      const res = await request(app)
+        .post('/api/referrals/earnings')
+        .send({ email: 'eli@example.com' })
+        .expect(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data.clicks).toBe(2);
+      expect(typeof res.body.data.lastClickedAt).toBe('string');
+      expect(Array.isArray(res.body.data.payouts)).toBe(true);
+      expect(res.body.data.payouts.length).toBeGreaterThan(0);
+      expect(res.body.data.payouts[0].netPayoutCents).toBe(475);
+    });
   });
 });

--- a/backend/routes/referrals.js
+++ b/backend/routes/referrals.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const ReferralCode = require('../models/ReferralCode');
+const Payout = require('../models/Payout');
 const adminSession = require('../middleware/adminSession');
 const {
   registerReferral,
@@ -91,6 +92,13 @@ router.post('/earnings', async (req, res) => {
     }
     const pendingOrders = record.pendingOrders || [];
     const recent = pendingOrders.slice(-10).reverse();
+
+    // Settlement history for this code (public but owner-gated by email lookup).
+    const payouts = await Payout.find({ creatorHandle: record.code })
+      .sort({ createdAt: -1 })
+      .limit(10)
+      .lean();
+
     return res.json({
       ok: true,
       data: {
@@ -98,11 +106,21 @@ router.post('/earnings', async (req, res) => {
         name: record.name,
         commissionRate: record.commissionRate,
         sales: record.sales,
+        clicks: record.clicks,
+        lastClickedAt: record.lastClickedAt,
         totalCommissionsCents: record.totalCommissionsCents,
         pendingCents: record.pendingCents,
         joinedAt: record.joinedAt,
         status: record.status,
         recent,
+        payouts: payouts.map((p) => ({
+          status: p.status,
+          totalCommissionsCents: p.totalCommissionsCents,
+          netPayoutCents: p.netPayoutCents,
+          orderCount: p.orderCount,
+          batchId: p.batchId,
+          createdAt: p.createdAt,
+        })),
       },
     });
   } catch (err) {


### PR DESCRIPTION
Adds clicks, conversion rate, and payout history to both public referral dashboards plus the admin table.

- \/api/referrals/earnings\ now returns \clicks\, \lastClickedAt\, and \payouts\ (owner-gated by email)
- Vite ReferralPage: conversion stat card + activity list (recent sales + payouts)
- Next /referrals: clicks + conversion cards and payout history
- Admin ReferralTab: Clicks column
- Backend test asserts the new fields (12 referral tests pass)